### PR TITLE
Fixing the Travis build for Dredd + PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
+sudo: required
 php:
   - 5.6
 before_install:
   - npm install -g dredd@1.0.1
 install: composer install
 before_script:
- - php artisan serve &
- - sleep 5
  - dredd
 
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",
         "symfony/css-selector": "2.8.*|3.0.*",
-        "symfony/dom-crawler": "2.8.*|3.0.*"
+        "symfony/dom-crawler": "2.8.*|3.0.*",
+        "ddelnano/dredd-hooks-php": "~1.0.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ea1fee525914154e6d6bbf071697b5a1",
-    "content-hash": "8b1485987e7c5949da82435d403e52e8",
+    "hash": "7a9e9e2f2b6140ccd1288744204da088",
+    "content-hash": "522ea231f4d9eed9992a057fbd0eff2c",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -1776,6 +1776,53 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "ddelnano/dredd-hooks-php",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ddelnano/dredd-hooks-php.git",
+                "reference": "eae48220aed21036a65257d855859ce3a1a25967"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ddelnano/dredd-hooks-php/zipball/eae48220aed21036a65257d855859ce3a1a25967",
+                "reference": "eae48220aed21036a65257d855859ce3a1a25967",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/dredd-hooks-php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dredd\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Domenic Del Nano",
+                    "email": "ddelnano@gmail.com"
+                }
+            ],
+            "description": "PHP hooks for the Dredd testing tool",
+            "homepage": "https://github.com/ddelnano/dredd-hooks-php/wiki",
+            "keywords": [
+                "dredd"
+            ],
+            "time": "2015-09-11 20:29:57"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",

--- a/dredd.yml
+++ b/dredd.yml
@@ -1,14 +1,14 @@
 dry-run: null
-hookfiles: null
-language: nodejs
+hookfiles: ./hooks*.php
+language: vendor/bin/dredd-hooks-php
 sandbox: false
-#server: php artisan serve
+server: php artisan serve
 server-wait: 5
 init: false
 custom: {}
 names: false
 only: []
-reporter: null
+reporter: apiary
 output: []
 header: []
 sorted: false
@@ -22,4 +22,4 @@ timestamp: false
 silent: false
 path: []
 blueprint: blueprint.md
-endpoint: 'http://localhost:8000'
+endpoint: 'http://localhost:8000/'

--- a/hooks-test.php
+++ b/hooks-test.php
@@ -1,0 +1,8 @@
+<?php
+
+use Dredd\Hooks;
+
+Hooks::beforeAll(function(&$transaction) {
+
+    echo "before all php debug";
+});


### PR DESCRIPTION
- Dredd to start server under test
- Dredd PHP hooks handler to `composer.json`
- `sudo: required` to avoid Travis's containter based infrastructure
- Sample `beforeAll` PHP hook in `hooks-test.php`
  ![image](https://cloud.githubusercontent.com/assets/79609/11969896/3a39469e-a8d6-11e5-823f-2796fffc4326.png)
- Apiary reporter to inspect the test
  <img width="1210" alt="screen shot 2015-12-22 at 17 59 51" src="https://cloud.githubusercontent.com/assets/79609/11969876/e499f92c-a8d5-11e5-8acc-68ed564e5c20.png">
